### PR TITLE
Refactoring, comments and fixes

### DIFF
--- a/examples/hn_embed.py
+++ b/examples/hn_embed.py
@@ -1,25 +1,52 @@
 from bytewax.dataflow import Dataflow
-from bytewax.connectors.stdio import StdOutput
 
 from embed.sources.url import HTTPInput
 from embed.processing.html import recurse_hn
-from embed.embedding.huggingface import huggingface_custom
-from embed.stores.qdrant import QdrantOutput
+from embed.embedding.huggingface import huggingface_custom, auto_tokenizer, auto_model
 
-from transformers import AutoTokenizer, AutoModel
-
-tokenizer = AutoTokenizer.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
-model = AutoModel.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
 
 flow = Dataflow()
+
+# Get the homepage of hackernews as the source
 flow.input(
-    "http_input", HTTPInput(urls=["https://news.ycombinator.com/"], poll_frequency=300)
+    "http_input",
+    HTTPInput(
+        urls=["https://news.ycombinator.com/"],
+        # Set poll_frequency to None to only fetch the page once,
+        # for testing.
+        poll_frequency=None,
+    ),
 )
+
+# The input returns a list of WebPages, so we use flat_map
+# to unpack the list into single items (only one in this case)
 flow.flat_map(lambda x: x)
+
+# Now we use `recurse_hn` to extract the urls of all the entries
+# in hackernews' homepage, and use flat_map again to unpack the
+# list of resulting urls
 flow.flat_map(lambda x: recurse_hn(x.html))
 
-# TODO - Deduplication
+# embed's WebPage object allows us to tokenize the html content
+# using a tokenizer from transformer's library
+flow.map(lambda x: x.parse_html(auto_tokenizer(MODEL_NAME)))
 
-flow.map(lambda x: x.parse_html(tokenizer))
-flow.map(lambda x: huggingface_custom(x, tokenizer, model, length=512))
-flow.output("output", QdrantOutput(collection_name="test_collection", vector_size=512))
+# We need to initialize a new tokenizer here, since this could
+# run in parallel with the other one thanks to bytewax, and we
+# can only use an instance at a time
+flow.map(
+    lambda x: huggingface_custom(
+        x, auto_tokenizer(MODEL_NAME), auto_model(MODEL_NAME), length=512
+    )
+)
+
+# Finally send the embeddings to qdrant
+# from embed.stores.qdrant import QdrantOutput
+# flow.output("output", QdrantOutput(collection_name="test_collection", vector_size=512))
+
+# This is a stdout output for testing without qdrant
+from bytewax.connectors.stdio import StdOutput
+
+flow.map(lambda x: f"Processed: {x}")
+flow.output("output", StdOutput())

--- a/examples/hn_embed.py
+++ b/examples/hn_embed.py
@@ -1,4 +1,5 @@
 from bytewax.dataflow import Dataflow
+from bytewax.connectors.stdio import StdOutput
 
 from embed.sources.url import HTTPInput
 from embed.processing.html import recurse_hn
@@ -24,8 +25,8 @@ flow.input(
 flow.flat_map(lambda x: x)
 
 # Now we use `recurse_hn` to extract the urls of all the entries
-# in hackernews' homepage, and use flat_map again to unpack the
-# list of resulting urls
+# in hackernews' homepage, fetch their content, and use flat_map
+# again to unpack the list of resulting webpages
 flow.flat_map(lambda x: recurse_hn(x.html))
 
 # embed's WebPage object allows us to tokenize the html content
@@ -46,7 +47,6 @@ flow.map(
 # flow.output("output", QdrantOutput(collection_name="test_collection", vector_size=512))
 
 # This is a stdout output for testing without qdrant
-from bytewax.connectors.stdio import StdOutput
 
 flow.map(lambda x: f"Processed: {x}")
 flow.output("output", StdOutput())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "embed"
 version = "0.0.1"
 authors = [
   { name="Zander Matheson", email="awmatheson@bytewax.io" },
+  { name="Federico Dolce", email="federico@bytewax.io" },
 ]
 description = "Composable real-time embedding pipelines"
 readme = "README.md"
@@ -18,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "bytewax>=0.16.1", 
+    "bytewax>=0.16.1",
     "requests",
     "websocket-client==1.5.1",
     "pydantic==1.10.7",
@@ -39,5 +40,5 @@ dev = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/awmatheson/rt-embed"
-"Bug Tracker" = "https://github.com/awmatheson/rt-embed/issues"
+"Homepage" = "https://github.com/bytewax/rt-embed"
+"Bug Tracker" = "https://github.com/bytewax/rt-embed/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 unstructured==0.6.2
+requests==2.31.0
+fake-useragent==1.1.3
 transformers==4.26.1
 torch==1.13.1
 sentencepiece==0.1.97
 pydantic==1.10.7
-qdrant-client==1.1.1[qdrant]
-bytewax==0.16.0
+qdrant-client==1.1.1
+bytewax==0.16.1
 websocket-client==1.5.1
+beautifulsoup4==4.12.2

--- a/src/embed/embedding/huggingface.py
+++ b/src/embed/embedding/huggingface.py
@@ -1,3 +1,7 @@
+"""
+Create embedding with a huggingface model and tokenizer
+"""
+
 from transformers import AutoTokenizer, AutoModel
 
 
@@ -28,7 +32,10 @@ def auto_model(model_name, cache_dir=None):
 def huggingface_custom(document, tokenizer, model, length=512):
     """
     Create an embedding from the provided document.
+
     Needs a huggingface tokenizer and model.
+    To instantiate a tokenizer and a model, you can use the
+    `auto_model` and `auto_tokenizer` functions in this module.
     """
     for chunk in document.text:
         inputs = tokenizer(

--- a/src/embed/embedding/huggingface.py
+++ b/src/embed/embedding/huggingface.py
@@ -1,7 +1,34 @@
-# create embedding with a huggingface model
+from transformers import AutoTokenizer, AutoModel
+
+
+def auto_tokenizer(model_name, cache_dir=None):
+    """
+    Returns an transformer's AutoTokenizer from a pretrained model name.
+
+    If cache_dir is not specified, transformer's default one will be used.
+
+    The first time this runs, it will download the required
+    model if it's not present in cache_dir.
+    """
+    return AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+
+
+def auto_model(model_name, cache_dir=None):
+    """
+    Returns an transformer's AutoModel from a pretrained model name.
+
+    If cache_dir is not specified, transformer's default one will be used.
+
+    The first time this runs, it will download the required
+    model if it's not present in cache_dir.
+    """
+    return AutoModel.from_pretrained(model_name, cache_dir=cache_dir)
+
+
 def huggingface_custom(document, tokenizer, model, length=512):
     """
-    Create an embedding from the provided document
+    Create an embedding from the provided document.
+    Needs a huggingface tokenizer and model.
     """
     for chunk in document.text:
         inputs = tokenizer(

--- a/src/embed/objects/base.py
+++ b/src/embed/objects/base.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional
+from typing import Optional
+
 from pydantic import BaseModel
 
 

--- a/src/embed/objects/webpage.py
+++ b/src/embed/objects/webpage.py
@@ -1,12 +1,13 @@
 import time
 import hashlib
-
-from fake_useragent import UserAgent
 import requests
-from requests.exceptions import RequestException
+
+from typing import Optional
 
 from embed.objects.base import Document
 
+from fake_useragent import UserAgent
+from requests.exceptions import RequestException
 from unstructured.partition.html import partition_html
 from unstructured.cleaners.core import (
     clean,
@@ -14,38 +15,41 @@ from unstructured.cleaners.core import (
     clean_non_ascii_chars,
 )
 from unstructured.staging.huggingface import chunk_by_attention_window
-from unstructured.staging.huggingface import stage_for_transformers
-
-from typing import Any, Optional
 
 
 class WebPage(Document):
     url: str
     html: Optional[str]
     content: Optional[str]
-    headers: Optional[dict] = {}
-    max_retries: Optional[int] = 3
-    wait_time: Optional[int] = 1
+    headers: Optional[dict] = None
+    max_retries: int = 3
+    wait_time: int = 1
 
     def __str__(self):
-        return f"WebPage: url={self.url}, html={self.html}, text={self.text}, metadata={self.metadata}"
+        return f"WebPage('{self.url}')"
 
     def get_page(self):
-        if self.headers == {}:
+        if self.headers is None:
             # make a user agent
             ua = UserAgent()
+            accept = [
+                "text/html",
+                "application/xhtml+xml",
+                "application/xml;q=0.9",
+                "image/webp",
+                "*/*;q=0.8",
+            ]
 
             self.headers = {
                 "User-Agent": ua.random,
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*"
-                ";q=0.8",
+                "Accept": ",".join(accept),
                 "Accept-Language": "en-US,en;q=0.5",
                 "Referrer": "https://www.google.com/",
                 "DNT": "1",
                 "Connection": "keep-alive",
                 "Upgrade-Insecure-Requests": "1",
             }
-        current_wait_time = self.wait_time
+
         # Send the initial request
         for i in range(self.max_retries + 1):
             try:
@@ -58,25 +62,16 @@ class WebPage(Document):
                 if i == self.max_retries:
                     print(f"skipping url {self.url}")
                     self.html = ""
-                print(f"Retrying in {current_wait_time} seconds...")
-                time.sleep(current_wait_time)
+                print(f"Retrying in {self.wait_time} seconds...")
+                time.sleep(self.wait_time)
                 i += 1
 
     # Clean the code and setup the dataclass
     def parse_html(self, tokenizer):
-        article_elements = partition_html(text=self.html)
-        self.content = clean_non_ascii_chars(
-            replace_unicode_quotes(
-                clean(
-                    " ".join(
-                        [
-                            str(x) if x.to_dict()["type"] == "NarrativeText" else ""
-                            for x in article_elements
-                        ]
-                    )
-                )
-            )
-        )
+        elements = partition_html(text=self.html)
+        elements = [x for x in elements if x.to_dict()["type"] == "NarrativeText"]
+        elements = " ".join([f"{x}" for x in elements])
+        self.content = clean_non_ascii_chars(replace_unicode_quotes(clean(elements)))
         self.text += chunk_by_attention_window(self.content, tokenizer)
         try:
             self.group_key = hashlib.md5(self.content[:2000].encode()).hexdigest()

--- a/src/embed/sources/url.py
+++ b/src/embed/sources/url.py
@@ -46,7 +46,7 @@ class HTTPInput(DynamicInput):
         self.wait_time = wait_time
 
     def build(self, worker_index, worker_count):
-        urls_per_worker = int(len(self.urls) / worker_count)
+        urls_per_worker = max(1, int(len(self.urls) / worker_count))
         worker_urls = self.urls[
             int(worker_index * urls_per_worker) : int(
                 worker_index * urls_per_worker + urls_per_worker


### PR DESCRIPTION
This PR goes around the codebase for some refactoring, fixes and some comments:

- in `requirements.txt` I added some missing dependencies, and also removed the `qdrant` optional feature from `qdrant-client` as it seems it's not needed
- I added two functions to instantiate the auto_model and auto_tokenizer in the library, and added a reference to them in the `huggingface_custom` function
- Removed some unused imports
- Fixed some type hints in WebPage
- Changed `WebPage.__str__` to avoid printing the whole html and text contents, as it makes everything hard to read if they are big enough
- Refactored `WebPage.parse_html` for readability
- added some comments to the hn_embed example

The `url.py` is the only place where I did change the functionality:
- added the possibility to only request the page once (for testing purposes) by passing `poll_frequency=None`
- moved from `datetime` to `time`, as it makes things simpler if we only need to know the number of elapsed seconds
- Previously the function was reducing the `self.poll_frequency` value by the time it took to make the request, at every poll. This would make the page be polled faster and faster, getting to a negative value for `poll_frequency`. Unless I'm missing something, this seemed like a bug, so I changed the code the keep `self.poll_frequency` always the same
- in the `build` function, if the number of workers was bigger than the number of urls, `int(len(self.urls) / worker_count)` would be truncated to 0, leading to no urls per worker. I added a `max(1, ...)` to make sure urls are sent to at least one worker.

